### PR TITLE
Add interactive mode to select filename

### DIFF
--- a/OMPlot/OMPlotGUI/main.cpp
+++ b/OMPlot/OMPlotGUI/main.cpp
@@ -192,11 +192,21 @@ int main(int argc, char *argv[])
       {
         fprintf(stdout, "Info:  This directory contains following result files:\n");
         for(int i=0;i<count;i++)
-          fprintf(stderr, "       * '%s'\n", resultFiles.at(i).toUtf8().constData());
+          fprintf(stdout, "         %d. %s\n", i+1, resultFiles.at(i).toUtf8().constData());
+        fprintf(stdout, "         0. another file\n");
 
-        fprintf(stderr, "Error: No filename specified.\n");
-        printUsage(true);
-        return 1;
+        int choise;
+        fprintf(stdout, "       Make your choice: ");
+        scanf("%d", &choise);
+        if(choise > 0 && choise <= count)
+          filename = resultFiles.at(choise-1);
+        else
+        {
+          if(choise != 0)
+            fprintf(stderr, "Error: Invalid index specified.\n");
+          printUsage(true);
+          return 1;
+        }
       }
     }
 


### PR DESCRIPTION
It is often anoying to pass the filename to OMPlot, especially if tab expansion is not available. Therefore, I added an interactive mode, where one has just to select the index of the correct result file if no filename is passed to OMPlot:
```
> OMPlot h
Info:  This directory contains following result files:
         1. BouncingBall_me_FMU_res.mat
         2. BouncingBall_res.mat
         3. foo.csv
         0. another file
       Make your choice: 1
```